### PR TITLE
Replace imp usage in pg_logger custom module loader

### DIFF
--- a/v5-unity/pg_logger.py
+++ b/v5-unity/pg_logger.py
@@ -31,7 +31,6 @@
 # NB: try to import the minimal amount of stuff in this module to lessen
 # the security attack surface
 
-import imp
 import sys
 import bdb # the KEY import here!
 import re
@@ -1446,7 +1445,7 @@ class PGLogger(bdb.Bdb):
         if self.custom_modules:
             for mn in self.custom_modules:
                 # http://code.activestate.com/recipes/82234-importing-a-dynamically-generated-module/
-                new_m = imp.new_module(mn)
+                new_m = types.ModuleType(mn)
                 exec(self.custom_modules[mn], new_m.__dict__) # exec in custom globals
                 user_globals.update(new_m.__dict__)
 


### PR DESCRIPTION
## Summary
- remove the deprecated `imp` import from `pg_logger` for Python 3.12 compatibility
- instantiate custom modules with `types.ModuleType` when loading user-provided modules

## Testing
- python3 v5-unity/bottle_server.py *(fails: third-party bottle==0.12.17 imports removed stdlib module `imp` on Python 3.12)*
- pytest *(fails: legacy Python 2 test files contain syntax incompatible with Python 3)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb3813464832d8a03cc3a0642e914