### PR TITLE
Serve index page at root

### DIFF
--- a/v5-unity/bottle_server.py
+++ b/v5-unity/bottle_server.py
@@ -31,6 +31,10 @@ import os
 def dummy_ok(name=None):
     return 'OK'
 
+@route('/')
+def serve_index():
+    return static_file('index.html', root='.')
+
 @route('/<filepath:path>')
 def index(filepath):
     return static_file(filepath, root='.')


### PR DESCRIPTION
## Summary
- add a dedicated Bottle route to serve index.html at the root path

## Testing
- `python v5-unity/bottle_server.py` *(fails: bottle requires the deprecated `imp` module, which is removed in Python 3.12)*

------
https://chatgpt.com/codex/tasks/task_b_68ccb9c69e8c832d9ad532f46ac76a0a