### PR TITLE
Fix C++ backend test runner for Python 3

### DIFF
--- a/v4-cokapi/backends/c_cpp/tests/run_test_from_scratch.py
+++ b/v4-cokapi/backends/c_cpp/tests/run_test_from_scratch.py
@@ -2,16 +2,23 @@ import os
 import subprocess
 import sys
 
-bn = os.path.splitext(sys.argv[1])[0]
+input_path = os.path.abspath(sys.argv[1])
+bn = os.path.splitext(input_path)[0]
 trace_f = bn + '.trace'
+trace_dir = os.path.dirname(trace_f)
+target_name = os.path.basename(trace_f)
+
 if os.path.exists(trace_f):
     os.remove(trace_f)
 
-subprocess.call(["make", trace_f]) # synchronous
-assert os.path.exists(trace_f)
+make_args = ["make", target_name]
+subprocess.check_call(make_args, cwd=trace_dir or None)  # synchronous
+if not os.path.exists(trace_f):
+    raise AssertionError(trace_f + " was not created")
 
 # print out trace_f to stdout
-for line in open(trace_f):
-    print line,
+with open(trace_f) as inf:
+    for line in inf:
+        sys.stdout.write(line)
 
 #os.remove(trace_f) # clean up


### PR DESCRIPTION
## Summary
- update the C/C++ backend test harness to run under Python 3
- ensure the script invokes `make` from the test directory and streams trace output without syntax errors

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_b_68ccdc557180832da9f02c62b6efdad5