### PR TITLE
Fix allow_all_modules preimport and add regression test

### DIFF
--- a/tests/test_pg_logger.py
+++ b/tests/test_pg_logger.py
@@ -1,0 +1,38 @@
+import sys
+from pathlib import Path
+import unittest
+
+V5_UNITY_DIR = Path(__file__).resolve().parents[1] / "v5-unity"
+if str(V5_UNITY_DIR) not in sys.path:
+    sys.path.insert(0, str(V5_UNITY_DIR))
+
+import pg_logger
+
+
+class ExecScriptAllowAllModulesTests(unittest.TestCase):
+
+    def test_from_import_preimported_when_allow_all_modules_enabled(self):
+        script = "from math import sqrt\nresult = sqrt(4)"
+
+        def finalizer(code, trace):
+            return {"code": code, "trace": trace}
+
+        result = pg_logger.exec_script_str_local(
+            script,
+            [],
+            cumulative_mode=False,
+            heap_primitives=False,
+            finalizer_func=finalizer,
+            allow_all_modules=True,
+        )
+
+        self.assertEqual(result["code"], script)
+        trace = result["trace"]
+        self.assertGreaterEqual(len(trace), 3)
+        self.assertEqual(trace[-1]["event"], "return")
+        self.assertEqual(trace[-1]["func_name"], "<module>")
+        self.assertSetEqual({entry.get("func_name") for entry in trace}, {"<module>"})
+
+
+if __name__ == "__main__":  # pragma: no cover
+    unittest.main()

--- a/v5-unity/pg_logger.py
+++ b/v5-unity/pg_logger.py
@@ -1470,7 +1470,8 @@ class PGLogger(bdb.Bdb):
                   for n in node.names:
                     all_modules_to_preimport.append(n.name)
                 elif isinstance(node, ast.ImportFrom):
-                  all_modules_to_preimport(node.module)
+                  if node.module:
+                    all_modules_to_preimport.append(node.module)
 
               for m in all_modules_to_preimport:
                 if m in script_str: # optimization: load only modules that appear in script_str


### PR DESCRIPTION
## Summary
- ensure ImportFrom nodes append module names for pre-import when allow_all_modules is enabled
- add a regression test covering from-import usage with exec_script_str_local allow_all_modules mode

## Testing
- python -m unittest tests.test_pg_logger

------
https://chatgpt.com/codex/tasks/task_b_68cce1e59948832d908dd35fa0a2456d